### PR TITLE
feat: add go-jsonnet wolfi package

### DIFF
--- a/go-jsonnet.yaml
+++ b/go-jsonnet.yaml
@@ -1,0 +1,55 @@
+package:
+  name: go-jsonnet
+  version: 0.20.0
+  epoch: 0
+  description: A feature-complete, production-ready implementation of Jsonnet in pure Go.
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    repositories:
+      - https://dl-cdn.alpinelinux.org/alpine/edge/main
+      - https://dl-cdn.alpinelinux.org/alpine/edge/community
+    packages:
+      - busybox
+      - curl
+      - go
+      - git
+
+pipeline:
+  - name: Fetch source
+    runs: |
+      curl -L -o go-jsonnet.tar.gz https://github.com/google/go-jsonnet/archive/refs/tags/v0.20.0.tar.gz
+      echo "bf9923a848dba65fa99f6e926221ab4222c2f259ba837d279b43917962bc7d70  go-jsonnet.tar.gz" | sha256sum -c
+      mkdir src
+      tar -xzf go-jsonnet.tar.gz -C src --strip-components=1
+
+  - name: Build binaries
+    working-directory: src
+    runs: |
+      export CGO_ENABLED=0
+      export GOFLAGS="-buildvcs=false"
+      go build -o jsonnet ./cmd/jsonnet
+      go build -o jsonnetfmt ./cmd/jsonnetfmt
+      go build -o jsonnet-deps ./cmd/jsonnet-deps
+
+  - name: Install binaries
+    runs: |
+      install -Dm755 src/jsonnet "${{targets.destdir}}/usr/bin/jsonnet"
+      install -Dm755 src/jsonnetfmt "${{targets.destdir}}/usr/bin/jsonnetfmt"
+      install -Dm755 src/jsonnet-deps "${{targets.destdir}}/usr/bin/jsonnet-deps"
+      install -Dm644 src/LICENSE "${{targets.destdir}}/usr/share/licenses/go-jsonnet/LICENSE"
+
+test:
+  pipeline:
+    - name: Binaries installation test
+      runs: |
+        ${{targets.destdir}}/usr/bin/jsonnet --version
+        ${{targets.destdir}}/usr/bin/jsonnetfmt --version
+        ${{targets.destdir}}/usr/bin/jsonnet-deps --help
+    - name: Run Go test suite
+      working-directory: src
+      runs: |
+        export CGO_ENABLED=0
+        go test ./...


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:https://github.com/wolfi-dev/os/issues/47437

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)
- [ ] If non-streamed package names no longer built, open PR to withdraw them (see [WITHDRAWING PACKAGES](https://github.com/wolfi-dev/os/blob/main/WITHDRAWING_PACKAGES.md))

#### For package updates (renames) in the base images
<!-- remove if unrelated -->
When updating packages part of base images (i.e. cgr.dev/chainguard/wolfi-base or ghcr.io/wolfi-dev/sdk)
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk images successfully build
- [ ] REQUIRED cgr.dev/chainguard/wolfi-base and ghcr.io/wolfi-dev/sdk contain no obsolete (no longer built) packages
- [ ] Upon launch, does `apk upgrade --latest` successfully upgrades packages or performs no actions

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
